### PR TITLE
Fix product data constructor handling

### DIFF
--- a/app/Data/Product/ProductData.php
+++ b/app/Data/Product/ProductData.php
@@ -21,9 +21,9 @@ class ProductData extends Data
         #[WithoutValidation]
         public Optional|int|null                 $categoryId,
 
-        public string                            $name,
+        public Optional|string|null              $name,
 
-        public string                            $price,
+        public Optional|string|null              $price,
         #[WithoutValidation]
         public UploadedFile|Optional|string|null $image,
         public ?string                           $description,
@@ -88,12 +88,14 @@ class ProductData extends Data
 
     public function toDatabase(): array
     {
-        return [
+        $data = [
             'name' => $this->name,
             'description' => $this->description,
             'price' => $this->price,
             'category_id' => $this->category?->id,
-            'image' => $this->image
+            'image' => $this->image,
         ];
+
+        return array_filter($data, fn ($value) => ! $value instanceof Optional);
     }
 }

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -81,9 +81,14 @@ class ProductController extends Controller
     /**
      * @throws Throwable
      */
-    public function update(ProductData $request, Product $product)
+    public function update(ProductData $requestData, Product $product)
     {
-        $product->update($request->toDatabase());
+        if (request()->hasFile('image')) {
+            request()->file('image')->storePublicly('images/products', 'public');
+            $requestData->image = request()->file('image')->hashName();
+        }
+
+        $product->update($requestData->toDatabase());
 
         return redirect()
             ->route('product.show', $product)


### PR DESCRIPTION
## Summary
- allow optional `name` and `price` when instantiating `ProductData`
- skip database fields that aren't provided

## Testing
- `npm test` *(fails: Missing script: "test")*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841fcddfea083289aadf42bf802d160